### PR TITLE
Drop item

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# Hackernews Clone - back-end
+# Hackernews Clone - backend
 
-## See also: [front-end](https://github.com/KIMB0/LSD_frontend).
+By Group E
 
-## See documentation, requirements and more [here](https://github.com/KIMB0/LSD_frontend/tree/master/Documents).
+### See also: [front-end](https://github.com/KIMB0/LSD_frontend).
+
+### See documentation, requirements and more [here](https://github.com/KIMB0/LSD_frontend/tree/master/Documents).

--- a/src/main/java/DataAccess/MongoDB.java
+++ b/src/main/java/DataAccess/MongoDB.java
@@ -20,8 +20,8 @@ import static com.mongodb.util.JSON.parse;
 public class MongoDB {
 
     // Setup of MONGO DB
-    private static MongoClientURI connectionString = new MongoClientURI("mongodb://188.226.184.108:27017");
-    //private static MongoClientURI connectionString = new MongoClientURI("mongodb://localhost:27017"); //For local test purposes
+    private static MongoClientURI connectionString = new MongoClientURI("mongodb://188.226.184.108:27017"); //TODO outcomment for prod use.
+    //private static MongoClientURI connectionString = new MongoClientURI("mongodb://localhost:27017"); //TODO outcomment for local test purposes.
 
     private static MongoClient client = new MongoClient(connectionString);
 
@@ -76,7 +76,14 @@ public class MongoDB {
                 .find(eq("id", ID))
                 .first();
 
-        return document.toJson();
+        try{
+            return document.toJson();
+        }
+        catch (NullPointerException ex){
+            ex.printStackTrace();
+        }
+        return null;
+
     }
 
     /**
@@ -85,7 +92,7 @@ public class MongoDB {
      * @param itemId Id of item to return as Document.
      * @return Item as Document type.
      */
-    public static Document getItemDocument(String itemId) {
+    public static Document getItemDocument(int itemId) {
         Document document = itemCollection
                 .find(eq("id", itemId))
                 .first();
@@ -230,7 +237,7 @@ public class MongoDB {
      * @throws NullPointerException if Item with specified ID does not exist.
      */
     public static void deleteItem(Item item) throws NullPointerException {
-        Document itemToDelete = getItemDocument(String.valueOf(item.getId()));
+        Document itemToDelete = getItemDocument(item.getId());
         if (itemToDelete == null) throw new NullPointerException("Item with specified ID not found.");
         itemCollection.deleteOne(itemToDelete);
     }
@@ -242,7 +249,7 @@ public class MongoDB {
      * @throws NullPointerException if Item with specified ID does not exist.
      */
     public static void deleteItem(int itemId) throws NullPointerException {
-        Document itemToDelete = getItemDocument(String.valueOf(itemId));
+        Document itemToDelete = getItemDocument(itemId);
         if (itemToDelete == null) throw new NullPointerException("Item with specified ID not found.");
         itemCollection.deleteOne(itemToDelete);
     }

--- a/src/main/java/DataAccess/MongoDB.java
+++ b/src/main/java/DataAccess/MongoDB.java
@@ -11,6 +11,7 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 
 import javax.print.Doc;
+import javax.validation.constraints.Null;
 
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.util.JSON.parse;
@@ -76,6 +77,20 @@ public class MongoDB {
                 .first();
 
         return document.toJson();
+    }
+
+    /**
+     * This method returns the specified Item as a Document.
+     *
+     * @param itemId Id of item to return as Document.
+     * @return Item as Document type.
+     */
+    public static Document getItemDocument(String itemId) {
+        Document document = itemCollection
+                .find(eq("id", itemId))
+                .first();
+
+        return document;
     }
 
     /**
@@ -208,8 +223,28 @@ public class MongoDB {
         return document != null;
     }
 
-    public void deleteItem(Item item) {
+    /**
+     * Deletes an Item based on specified Item object.
+     *
+     * @param item Item to delete.
+     * @throws NullPointerException if Item with specified ID does not exist.
+     */
+    public static void deleteItem(Item item) throws NullPointerException {
+        Document itemToDelete = getItemDocument(String.valueOf(item.getId()));
+        if (itemToDelete == null) throw new NullPointerException("Item with specified ID not found.");
+        itemCollection.deleteOne(itemToDelete);
+    }
 
+    /**
+     * Deletes an Item based on specified Item ID integer.
+     *
+     * @param itemId ID of Item to delete.
+     * @throws NullPointerException if Item with specified ID does not exist.
+     */
+    public static void deleteItem(int itemId) throws NullPointerException {
+        Document itemToDelete = getItemDocument(String.valueOf(itemId));
+        if (itemToDelete == null) throw new NullPointerException("Item with specified ID not found.");
+        itemCollection.deleteOne(itemToDelete);
     }
 
     public void deleteUser(User user) {
@@ -275,9 +310,10 @@ public class MongoDB {
 
     /**
      * This method is made for the front-end to display the latest thirty stories easily.
+     *
      * @return latest thirty stories as JSON
      */
-    public static String getLastThirty(){
+    public static String getLastThirty() {
         StringBuilder items = new StringBuilder();
         MongoCursor<Document> cursor = itemCollection.find(new BasicDBObject("type", "story")).sort(new BasicDBObject("_id", -1)).limit(30).iterator();
         return iterateCollection(items, cursor);

--- a/src/main/java/Routes/ItemRoute.java
+++ b/src/main/java/Routes/ItemRoute.java
@@ -41,14 +41,14 @@ public class ItemRoute {
             responseContainer = "String")
     @ApiResponses(
             value = {
-                    @ApiResponse(code = 204, message = "No content/items found"),
+                    @ApiResponse(code = 404, message = "No content/items found"),
                     @ApiResponse(code = 200, message = "All items has been retrieved")
             })
     public Response item() {
         requests.inc();
         if(MongoDB.getAllItems().isEmpty()) {
-            logger.error("Returned code 204 - no items were retrieved.");
-            return Response.status(204).entity("No Items has been retrieved. Could be a server error").type(MediaType.TEXT_PLAIN).build();
+            logger.error("Returned code 404 - no items were retrieved.");
+            return Response.status(404).entity("No Items has been retrieved. Could be a server error").type(MediaType.TEXT_PLAIN).build();
         }
         logger.info("All items were retrieved from host");
 
@@ -66,15 +66,15 @@ public class ItemRoute {
             responseContainer = "String")
     @ApiResponses(
             value = {
-                    @ApiResponse(code = 204, message = "(Content) Item ID not found"),
+                    @ApiResponse(code = 404, message = "(Content) Item ID not found"),
                     @ApiResponse(code = 200, message = "Item ID found successfully")
     })
     public Response item(@PathParam("id") int id) {
         requests.inc();
         if(MongoDB.getItem(id) == null) {
-            logger.error("Returned code 204 - no item with id " + id + " found.",
+            logger.error("Returned code 404 - no item with id " + id + " found.",
                     new NullPointerException("No Item ID found"));
-            return Response.status(204).entity("Item not found").type(MediaType.TEXT_PLAIN).build();
+            return Response.status(404).entity("Item not found").type(MediaType.TEXT_PLAIN).build();
         }
         logger.info("Item ID: " + id + " retrieved!");
         return Response.status(200).entity(MongoDB.getItem(id)).build();
@@ -346,9 +346,9 @@ public class ItemRoute {
             MongoDB.deleteItem(itemId);
         }
         catch (NullPointerException ex){
-            logger.error("Returned code 204 - no item with id " + itemId + " found.",
+            logger.error("Returned code 404 - no item with id " + itemId + " found.",
                     ex.getMessage());
-            return Response.status(204).entity("Item not found").type(MediaType.TEXT_PLAIN).build();
+            return Response.status(404).entity("Item not found").type(MediaType.TEXT_PLAIN).build();
         }
 
         return Response.ok().entity("Item successfully deleted.").build();

--- a/src/main/java/Routes/ItemRoute.java
+++ b/src/main/java/Routes/ItemRoute.java
@@ -335,5 +335,26 @@ public class ItemRoute {
         return Response.status(200).entity(itemDocument.toJson()).build();
     }
 
+    @DELETE
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("{id}")
+    public Response dropItem(InputStream json, @PathParam("id") int itemId){
+        requests.inc();
+
+        try{
+            MongoDB.deleteItem(itemId);
+        }
+        catch (NullPointerException ex){
+            logger.error("Returned code 204 - no item with id " + itemId + " found.",
+                    ex.getMessage());
+            return Response.status(204).entity("Item not found").type(MediaType.TEXT_PLAIN).build();
+        }
+
+        return Response.ok().entity("Item successfully deleted.").build();
+
+
+    }
+
 
 }


### PR DESCRIPTION
Closes #30.
It's now possible to drop/delete an Item by sending a HTTP DELETE request to the desired Item URI.
For example, sending a `DELETE` request to [/hackernews/item/1000000](http://94.130.57.246:9000/hackernews/item/1000000) will delete item number one million.

This is done for better back-to-back testing, both in the backend and in the frontend.

Please review @KIMB0 or @AlexanderFalk.

(PS: I accidentally named the branch "drop_user" instead of "drop_item". This branch & PR creates *item* functionality.  